### PR TITLE
ignore target.xcconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+target.xcconfig
+
 # git ignore template from: http://cocoaheads.tumblr.com/post/1350304132/gitignore-template-for-xcode3-4
 
 # Mac OS X Finder


### PR DESCRIPTION
clutters up appium's status output
