### PR TITLE
Have a button to launch Safari, rather than launching after a delay

### DIFF
--- a/SafariLauncher/AppDelegate.m
+++ b/SafariLauncher/AppDelegate.m
@@ -53,8 +53,6 @@ static BOOL foregroungCheckFlag = false;
 {
     // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
         if(foregroungCheckFlag){
-        Preferences *preferences = [Preferences sharedInstance];
-        [SafariLauncher launch:preferences.launchUrl withDelay:preferences.nonStartDelay];
     }
 }
 
@@ -66,11 +64,7 @@ static BOOL foregroungCheckFlag = false;
 - (BOOL)application:(UIApplication *)application handleOpenURL:(NSURL *)url
 {
     foregroungCheckFlag = false;
-    Preferences *preferences = [Preferences sharedInstance];
-    if (!url) {
-        [SafariLauncher launch:preferences.launchUrl withDelay:preferences.nonStartDelay];
-    }else{
-        
+    
         NSString *launchUrl = [[url absoluteString] substringFromIndex:5];
         if([launchUrl hasPrefix:@"http//"]){
             launchUrl = [launchUrl stringByReplacingOccurrencesOfString:@"http//"
@@ -80,8 +74,8 @@ static BOOL foregroungCheckFlag = false;
                                                              withString:@"https://"];
         }
         
-        [SafariLauncher launch:launchUrl withDelay:preferences.nonStartDelay];
-    }
+        [SafariLauncher launch:launchUrl];
+    
     return YES;
 }
 

--- a/SafariLauncher/Preferences.h
+++ b/SafariLauncher/Preferences.h
@@ -16,8 +16,6 @@
 }
 
 @property (readonly, nonatomic) NSString *launchUrl;
-@property (readonly, nonatomic) NSUInteger startDelay;
-@property (readonly, nonatomic) NSUInteger nonStartDelay;
 
 // Singleton
 + (Preferences *)sharedInstance;

--- a/SafariLauncher/Preferences.m
+++ b/SafariLauncher/Preferences.m
@@ -9,15 +9,11 @@
 #import "Preferences.h"
 
 static NSString * const PREF_LAUNCH_URL = @"preference_launchUrl";
-static NSString * const PREF_START_DELAY = @"preference_startDelay";
 static NSString * const DEFAULT_URL = @"http://www.google.com";
-static NSUInteger const NON_START_DELAY = 0;
 
 @implementation Preferences
 
 @synthesize launchUrl = launchUrl_;
-@synthesize startDelay = startDelay_;
-@synthesize nonStartDelay = nonStartDelay_;
 
 /*
 static Preferences *singleton = nil;
@@ -42,9 +38,8 @@ static Preferences *singleton = nil;
 + (void) initPreferences {
     NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
     id launchUrl = [userDefaults objectForKey:PREF_LAUNCH_URL];
-    id startDelay = [userDefaults objectForKey:PREF_START_DELAY];
     
-    if (launchUrl == nil || startDelay == nil) {
+    if (launchUrl == nil) {
         NSLog(@"App setting not found. Initializing app settings to default values.");
         
         NSString* bundlePath = [[NSBundle mainBundle] bundlePath];
@@ -86,14 +81,6 @@ static Preferences *singleton = nil;
         launchUrl_ = [[Preferences getDefaultUrl] absoluteString];
         [defaults setObject:launchUrl_ forKey:PREF_LAUNCH_URL];
     }
-    
-    startDelay_ = [defaults integerForKey:PREF_START_DELAY];
-    if (!startDelay_) {
-        startDelay_ = 20;
-        [defaults setObject:@"0" forKey:PREF_START_DELAY];
-    }
-
-    nonStartDelay_ = NON_START_DELAY;
     
     [defaults synchronize];
     return self;

--- a/SafariLauncher/SafariLauncher.h
+++ b/SafariLauncher/SafariLauncher.h
@@ -9,5 +9,5 @@
 #import <Foundation/Foundation.h>
 
 @interface SafariLauncher : NSObject
-+ (void)launch:(NSString *)url withDelay:(NSUInteger)delay;
++ (void)launch:(NSString *)url;
 @end

--- a/SafariLauncher/SafariLauncher.m
+++ b/SafariLauncher/SafariLauncher.m
@@ -11,11 +11,8 @@
 
 @implementation SafariLauncher
 
-+ (void)launch:(NSString *)url withDelay:(NSUInteger)delay{
++ (void)launch:(NSString *)url {
     Preferences *preferences = [Preferences sharedInstance];
-
-    NSLog(@"Waiting for %lu seconds", (unsigned long)delay);
-    [NSThread sleepForTimeInterval:delay];
     
     NSURL *launchUrl = [NSURL URLWithString: url];
     

--- a/SafariLauncher/ViewController.h
+++ b/SafariLauncher/ViewController.h
@@ -11,6 +11,7 @@
 @interface ViewController : UIViewController{
     UILabel *titleLabel;
     UILabel *infoLabel;
+    UIButton *launchButton;
 }
 
 @property (nonatomic, strong) NSTimer *delayTimer;

--- a/SafariLauncher/ViewController.m
+++ b/SafariLauncher/ViewController.m
@@ -33,32 +33,40 @@ NSUInteger secondsLeft;
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+    Preferences *preferences = [Preferences sharedInstance];
     // Do any additional setup after loading the view.
     int fontSize = self.view.bounds.size.height/25;
     
     NSLog(@"  height - %02f : width - %02f", self.view.bounds.size.height, self.view.bounds.size.width);
     titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(self.view.bounds.size.width/4.0f,
-                                                      self.view.bounds.size.height/2.0f,
-                                                      self.view.bounds.size.width/2.0f,
+                                                      10,
+                                                      self.view.bounds.size.width,
                                                       50)]; 
     titleLabel.text = @"Safari Launcher";
     titleLabel.textColor = [UIColor blueColor];
     titleLabel.font = [UIFont fontWithName:@"Verdana" size:fontSize];
     
+    launchButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
+    [launchButton addTarget:self action:@selector(launchSafari) forControlEvents:UIControlEventTouchUpInside];
+    [launchButton setTitle:@"Launch Safari" forState:UIControlStateNormal];
+    [launchButton setIsAccessibilityElement:YES];
+    [launchButton setAccessibilityLabel:@"launch safari"];
+    
+    CGRect bounds = self.view.bounds;
+    launchButton.frame = CGRectMake(80.0, 210.0, 200.0, 60.0);
+    launchButton.center = CGPointMake(CGRectGetMidX(bounds), CGRectGetMidY(bounds));
+    
     infoLabel = [[UILabel alloc] initWithFrame:CGRectMake(0,
                                                       self.view.bounds.size.height-50.0f,
                                                       self.view.bounds.size.width,
                                                       50)];
-    infoLabel.text = @"Status:";
+    infoLabel.text = [NSString stringWithFormat:@"   url: %@", preferences.launchUrl];
     infoLabel.layer.borderColor = [UIColor blackColor].CGColor;
     infoLabel.layer.borderWidth = 3.0;
     
     [self.view addSubview:titleLabel];
+    [self.view addSubview:launchButton];
     [self.view addSubview:infoLabel];
-    
-    Preferences *preferences = [Preferences sharedInstance];
-    secondsLeft = preferences.startDelay;
-    self.delayTimer = [NSTimer scheduledTimerWithTimeInterval:1.0 target:self selector:@selector(delayCountdown) userInfo:nil repeats:YES];
 }
 
 - (void)viewDidUnload
@@ -74,18 +82,6 @@ NSUInteger secondsLeft;
     return (interfaceOrientation == UIInterfaceOrientationPortrait);
 }
 
--(void) delayCountdown {
-    secondsLeft--;
-    infoLabel.text = [NSString stringWithFormat:@"  Pausing %02lu seconds before launch", (unsigned long)secondsLeft];
-    
-    NSLog(@"delay: %lu", (unsigned long)secondsLeft);
-    if (secondsLeft <= 0) {
-        [self.delayTimer invalidate];
-        self.delayTimer = nil;
-        [self launchSafari];
-    }
-}
-
 -(void) launchSafari{
     Preferences *preferences = [Preferences sharedInstance];
     NSArray * args = [[NSProcessInfo processInfo] arguments];
@@ -94,7 +90,7 @@ NSUInteger secondsLeft;
         urlArg = [args objectAtIndex: 1];
     }
     infoLabel.text = [NSString stringWithFormat:@"  Launching: %@", urlArg];
-    [SafariLauncher launch:urlArg withDelay:preferences.nonStartDelay];
+    [SafariLauncher launch:urlArg];
 }
 
 @end

--- a/SafariLauncher/ViewController.m
+++ b/SafariLauncher/ViewController.m
@@ -19,7 +19,7 @@
 @implementation ViewController
 @synthesize delayTimer;
 
-int secondsLeft;
+NSUInteger secondsLeft;
 
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
@@ -76,9 +76,9 @@ int secondsLeft;
 
 -(void) delayCountdown {
     secondsLeft--;
-    infoLabel.text = [NSString stringWithFormat:@"  Pausing %02d seconds before launch", secondsLeft];
+    infoLabel.text = [NSString stringWithFormat:@"  Pausing %02lu seconds before launch", (unsigned long)secondsLeft];
     
-    NSLog(@"delay: %d", secondsLeft);
+    NSLog(@"delay: %lu", (unsigned long)secondsLeft);
     if (secondsLeft <= 0) {
         [self.delayTimer invalidate];
         self.delayTimer = nil;


### PR DESCRIPTION
I realize this pretty much changes the entire app. Not sure if you would want this as "version 2" or a branch, or even a separate project. Here's the reasoning:

We want to have a button to launch safari, as part of running a Safari test on iOS devices with Appium.
This way Appium can start SafariLauncher as it would with a normal app test, click the button once connection is established, then switch over to using Safari.

We used to start Instruments, and after SafariLauncher launched Safari, Instruments would crash in the background and we wouldn't care, but as of iOS 8.0, it looks like Instruments hangs when the app under test is suspended. This causes appium to hang along with instruments.

We have other workarounds, but clicking on a button allows us to make sure that Instruments was able to launch SafariLauncher successfully, and there's less possibilities for weird async bugs related to the automatic 1second delay.

what do you think @snevesbarros 